### PR TITLE
Fix wheel building

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal = 1
+universal = 0


### PR DESCRIPTION
Package is no longer universal, as we dropped Python 2 support.